### PR TITLE
Make it possible to disable commands dynamically

### DIFF
--- a/mautrix/bridge/commands/handler.py
+++ b/mautrix/bridge/commands/handler.py
@@ -193,6 +193,7 @@ class CommandEvent:
 
 
 CommandHandlerFunc = Callable[[CommandEvent], Awaitable[Any]]
+IsEnabledForFunc = Callable[[CommandEvent], bool]
 
 
 class CommandHandler:
@@ -213,6 +214,7 @@ class CommandHandler:
     management_only: bool
     needs_admin: bool
     needs_auth: bool
+    is_enabled_for: IsEnabledForFunc
 
     _help_text: str
     _help_args: str
@@ -220,7 +222,9 @@ class CommandHandler:
 
     def __init__(self, handler: CommandHandlerFunc, management_only: bool, name: str,
                  help_text: str, help_args: str, help_section: HelpSection,
-                 needs_auth: bool, needs_admin: bool, **kwargs) -> None:
+                 needs_auth: bool, needs_admin: bool,
+                 is_enabled_for: IsEnabledForFunc = lambda _: True,
+                 **kwargs) -> None:
         """
         Args:
             handler: The function handling the execution of this command.
@@ -243,6 +247,7 @@ class CommandHandler:
         self._help_text = help_text
         self._help_args = help_args
         self.help_section = help_section
+        self.is_enabled_for = is_enabled_for
 
     async def get_permission_error(self, evt: CommandEvent) -> Optional[str]:
         """Returns the reason why the command could not be issued.
@@ -392,6 +397,8 @@ class CommandProcessor:
         command = command.lower()
         try:
             handler = command_handlers[command]
+            if not handler.is_enabled_for(evt):
+                raise KeyError()
         except KeyError:
             try:
                 handler = command_aliases[command]

--- a/mautrix/bridge/commands/handler.py
+++ b/mautrix/bridge/commands/handler.py
@@ -395,20 +395,16 @@ class CommandProcessor:
                                is_management=is_management, has_bridge_bot=has_bridge_bot)
         orig_command = command
         command = command.lower()
-        try:
-            handler = command_handlers[command]
-            if not handler.is_enabled_for(evt):
-                raise KeyError()
-        except KeyError:
-            try:
-                handler = command_aliases[command]
-            except KeyError:
-                if sender.command_status and "next" in sender.command_status:
-                    args.insert(0, orig_command)
-                    evt.command = ""
-                    handler = sender.command_status["next"]
-                else:
-                    handler = command_handlers["unknown-command"]
+
+        handler = command_handlers.get(command) or command_aliases.get(command)
+        if handler is None or not handler.is_enabled_for(evt):
+            if sender.command_status and "next" in sender.command_status:
+                args.insert(0, orig_command)
+                evt.command = ""
+                handler = sender.command_status["next"]
+            else:
+                handler = command_handlers["unknown-command"]
+
         try:
             await self._run_handler(handler, evt)
         except Exception:

--- a/mautrix/bridge/commands/handler.py
+++ b/mautrix/bridge/commands/handler.py
@@ -396,7 +396,7 @@ class CommandProcessor:
         orig_command = command
         command = command.lower()
 
-        handler = command_handlers.get(command) or command_aliases.get(command)
+        handler = command_handlers.get(command, command_aliases.get(command))
         if handler is None or not handler.is_enabled_for(evt):
             if sender.command_status and "next" in sender.command_status:
                 args.insert(0, orig_command)

--- a/mautrix/bridge/commands/meta.py
+++ b/mautrix/bridge/commands/meta.py
@@ -45,7 +45,7 @@ async def _get_help_text(evt: CommandEvent) -> str:
     if cache_key not in help_cache:
         help_sections: Dict[HelpSection, List[str]] = {}
         for handler in command_handlers.values():
-            if handler.has_help and handler.has_permission(cache_key):
+            if handler.has_help and handler.has_permission(cache_key) and handler.is_enabled_for(evt):
                 help_sections.setdefault(handler.help_section, [])
                 help_sections[handler.help_section].append(handler.help + "  ")
         help_sorted = sorted(help_sections.items(), key=lambda item: item[0].order)


### PR DESCRIPTION
This allows for hiding them completely depending on e.g. a config setting, or arbitrary sender rules (up to the implementing bridge).

Also accidentally upstreamed already to https://github.com/mautrix/python/pull/56 – no harm done (though I planned for it to pass here first), but we probably want this for ourselves regardless.